### PR TITLE
Changed installation task for the 'power-cycle' command.  It now spec…

### DIFF
--- a/ansible/site.yml
+++ b/ansible/site.yml
@@ -10,6 +10,9 @@
 - hosts: power_controllers
   tasks:
     - name: Install the power cycle utility
-      pip: name='git+http://github.com/burlington-arc/power-cycle.git#egg=power-cycle'
+      pip:
+        name: 'git+http://github.com/burlington-arc/power-cycle.git#egg=power-cycle'
+        editable: false
+
 
 - include: setup-ssh-users.yml


### PR DESCRIPTION
…ifies

'editable: False', so that the installation survives a reboot.  Ansible's pip
module defaults to installing Python modules in 'development' mode, which
doesn't seem to survive rebooting on the Pi.