### PR TITLE
Updated the openvpn server configuration.  It was specifying a

### DIFF
--- a/ansible/host_vars/barcpi004.yml
+++ b/ansible/host_vars/barcpi004.yml
@@ -2,8 +2,8 @@ ansible_user: 'pi'
 ansible_become: true
 ansible_become_method: 'sudo'
 ansible_become_user: 'root'
-aprx_user = pi
-aprx_group = pi
+aprx_user:  'pi'
+aprx_group: 'pi'
 direwolf_port: 9001
 
 share_tnc_device:  "localhost:9001"

--- a/ansible/roles/openvpn_server/templates/server.conf.j2
+++ b/ansible/roles/openvpn_server/templates/server.conf.j2
@@ -104,7 +104,6 @@ tls-server
 ifconfig 10.75.0.1 255.255.255.0
 ifconfig-pool 10.75.0.2 10.75.0.199 255.255.255.0
 route 10.75.0.0 255.255.255.0
-push "route-gateway 10.75.0.1"
 
 # Maintain a record of client <-> virtual IP address
 # associations in this file.  If OpenVPN goes down or


### PR DESCRIPTION
push "route-gateway" command that was preventing the client
from setting a default route to the remote subnet.

Updating the openvpn server also revealed a minor syntax error in the
host variables file for 'barcpi004.yml'.  It was mixing the
name: value and name=value syntaxes, which isn't allowed.